### PR TITLE
Uncomment `applyWindow` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ To require all window functions, include the top-level `window-function` module:
 ```javascript
 var wfuncs = require('window-function')
 
+var signal = [-1, 0, 1, 0, -1, 0]
+
+var windowedSignal = wfuncs.applyWindow(signal, wfuncs.blackmanHarris)
+```
+
+You can also apply the window functions yourself:
+
+```javascript
+var wfuncs = require('window-function')
+
 var value = wfuncs.blackmanHarris( 50, 101 )
 ```
 

--- a/index.js
+++ b/index.js
@@ -17,10 +17,10 @@ module.exports = {
   flatTop: require('./flat-top'),
   cosine: require('./cosine'),
   gaussian: require('./gaussian'),
-  tukey: require('./tukey')
+  tukey: require('./tukey'),
+  applyWindow: applyWindow
 }
 
-/*
 function applyWindow(signal, func) {
   var i, n=signal.length, args=[0,n]
 
@@ -36,7 +36,7 @@ function applyWindow(signal, func) {
   return signal;
 }
 
-
+/*
 function generate(func, N) {
   var i, args=[0,N]
   var signal = new Array(N);

--- a/test/test.js
+++ b/test/test.js
@@ -45,7 +45,7 @@ describe('window functions return a finite number',function() {
   })
 })
 
-/*describe('applies a window function',function() {
+describe('applies a window function',function() {
   
   var x
 
@@ -54,18 +54,19 @@ describe('window functions return a finite number',function() {
   })
 
   it('applies a window to a signal',function() {
-    wfunc.window( x, wfunc.hamming )
+    var y = wfunc.applyWindow( x, wfunc.hamming )
+    assert(y.length === x.length);
   })
 
   it('passes extra arguments to a window function',function() {
-    wfunc.window( x, wfunc.gaussian, 0.1 )
+    wfunc.applyWindow( x, wfunc.gaussian, 0.1 )
     assert( isFinite(x[0]), 'samples are finite' )
     assert( x[0] < 1e-8, 'samples have been windowed' )
   })
 })
 
 
-
+/*
 describe('generates a window function',function() {
   
   it('constructs an window function array',function() {


### PR DESCRIPTION
Using your library I noticed I was writing an `applyWindow` helper myself. Upon inspecting your code I noticed it already existed but was commented out.

This PR functions as a suggestion to uncomment it, since I believe it has high re-usability in combination with the functions. Let me know what you think.

By accident my IDE also ran Prettify over your code, that it the reason you see some styling changed. Let me know if you prefer to have a more pure edit and I'll remove the Prettify edit.